### PR TITLE
PeaceLetter (Post) 생성 기능 구현

### DIFF
--- a/src/main/java/com/findby/image/Image.java
+++ b/src/main/java/com/findby/image/Image.java
@@ -2,11 +2,13 @@ package com.findby.image;
 
 import com.findby.post.Post;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image {
     @Id

--- a/src/main/java/com/findby/image/Image.java
+++ b/src/main/java/com/findby/image/Image.java
@@ -1,18 +1,30 @@
 package com.findby.image;
 
 import com.findby.post.Post;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long imageId;
 
     public String url;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "post_id", referencedColumnName = "postId")
     public Post post;
+
+    private Image(String url, Post post) {
+        this.url = url;
+        this.post = post;
+    }
+
+    public static Image of(String url, Post post) {
+        return new Image(url, post);
+    }
 }

--- a/src/main/java/com/findby/orphan/Orphan.java
+++ b/src/main/java/com/findby/orphan/Orphan.java
@@ -2,32 +2,34 @@ package com.findby.orphan;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import javax.persistence.*;
 
 @Entity
 @Builder
+@Getter
 @AllArgsConstructor
 public class Orphan {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long orphanId;
+    private Long orphanId;
 
-    public String name;
+    private String name;
 
-    public Integer age;
+    private Integer age;
 
-    public Double latitude;
+    private Double latitude;
 
-    public Double longitude;
+    private Double longitude;
 
-    public String gender;
+    private String gender;
 
-    public String look;
+    private String look;
 
-    public String countryCode;
+    private String countryCode;
 
-    public String countryName;
+    private String countryName;
 
     public Orphan() {
 

--- a/src/main/java/com/findby/orphan/Orphan.java
+++ b/src/main/java/com/findby/orphan/Orphan.java
@@ -1,26 +1,35 @@
 package com.findby.orphan;
 
-import com.findby.post.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 import javax.persistence.*;
 
 @Entity
+@Builder
+@AllArgsConstructor
 public class Orphan {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long orphanId;
 
     public String name;
 
     public Integer age;
 
-    public String missedLocation;
+    public Double latitude;
 
-    public String sex;
+    public Double longitude;
+
+    public String gender;
 
     public String look;
 
-    @ManyToOne
-    @JoinColumn(name = "post_id", referencedColumnName = "postId")
-    public Post post;
+    public String countryCode;
+
+    public String countryName;
+
+    public Orphan() {
+
+    }
 }

--- a/src/main/java/com/findby/orphan/service/dtos/OrphanResponse.java
+++ b/src/main/java/com/findby/orphan/service/dtos/OrphanResponse.java
@@ -1,0 +1,35 @@
+package com.findby.orphan.service.dtos;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrphanResponse {
+    private final Long orphanId;
+    private final String name;
+    private final Integer age;
+    private final Double latitude;
+    private final Double longitude;
+    private final String gender;
+    private final String look;
+    private final String countryCode;
+    private final String countryName;
+
+    public static OrphanResponse of(
+            Long orphanId,
+            String name,
+            Integer age,
+            Double latitude,
+            Double longitude,
+            String gender,
+            String look,
+            String countryCode,
+            String countryName
+    ) {
+        return new OrphanResponse(
+                orphanId, name, age, latitude, longitude, gender, look, countryCode, countryName
+        );
+    }
+}

--- a/src/main/java/com/findby/post/Post.java
+++ b/src/main/java/com/findby/post/Post.java
@@ -1,11 +1,17 @@
 package com.findby.post;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import com.findby.orphan.Orphan;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Post {
     @Id
@@ -17,6 +23,10 @@ public class Post {
     public String title;
 
     public String content;
+
+    @OneToOne
+    @JoinColumn(name = "orphan_id")
+    public Orphan orphan;
 
     public LocalDateTime createAt;
 

--- a/src/main/java/com/findby/post/Post.java
+++ b/src/main/java/com/findby/post/Post.java
@@ -1,21 +1,23 @@
 package com.findby.post;
 
+import com.findby.image.Image;
 import com.findby.orphan.Orphan;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Post {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long postId;
 
     public String password;
@@ -24,9 +26,12 @@ public class Post {
 
     public String content;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "orphan_id")
     public Orphan orphan;
+
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    public List<Image> images = new ArrayList<>();
 
     public LocalDateTime createAt;
 
@@ -35,4 +40,29 @@ public class Post {
     public Boolean isDone;
 
     public String email;
+
+    public Post(String password, String title, String content, Orphan orphan, List<String> images, LocalDateTime createAt, LocalDateTime updateAt, Boolean isDone, String email) {
+        this.password = password;
+        this.title = title;
+        this.content = content;
+        this.orphan = orphan;
+        this.images = images.stream().map((url) -> Image.of(url, this)).collect(Collectors.toList());
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+        this.isDone = isDone;
+        this.email = email;
+    }
+
+    public static Post of(
+            String password,
+            String title,
+            String content,
+            String email,
+            Orphan orphan,
+            List<String> images
+    ) {
+        return new Post(
+                password, title, content, orphan, images, LocalDateTime.now(), LocalDateTime.now(), false, email
+        );
+    }
 }

--- a/src/main/java/com/findby/post/Post.java
+++ b/src/main/java/com/findby/post/Post.java
@@ -12,6 +12,8 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.AUTO)
     public Long postId;
 
+    public String password;
+
     public String title;
 
     public String content;

--- a/src/main/java/com/findby/post/Post.java
+++ b/src/main/java/com/findby/post/Post.java
@@ -18,30 +18,30 @@ import java.util.stream.Collectors;
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long postId;
+    private Long postId;
 
-    public String password;
+    private String password;
 
-    public String title;
+    private String title;
 
-    public String content;
+    private String content;
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "orphan_id")
     public Orphan orphan;
 
     @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-    public List<Image> images = new ArrayList<>();
+    private List<Image> images = new ArrayList<>();
 
-    public LocalDateTime createAt;
+    private LocalDateTime createAt;
 
-    public LocalDateTime updateAt;
+    private LocalDateTime updateAt;
 
-    public Boolean isDone;
+    private Boolean isDone;
 
-    public String email;
+    private String email;
 
-    public Post(String password, String title, String content, Orphan orphan, List<String> images, LocalDateTime createAt, LocalDateTime updateAt, Boolean isDone, String email) {
+    private Post(String password, String title, String content, Orphan orphan, List<String> images, LocalDateTime createAt, LocalDateTime updateAt, Boolean isDone, String email) {
         this.password = password;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/findby/post/controller/PostController.java
+++ b/src/main/java/com/findby/post/controller/PostController.java
@@ -3,10 +3,12 @@ package com.findby.post.controller;
 import com.findby.common.CommonResponse;
 import com.findby.common.swagger.post.*;
 
+import com.findby.post.service.PostService;
 import com.findby.post.service.dtos.PostRequest;
 import com.findby.post.service.dtos.PostResponse;
 import com.findby.post.service.dtos.PostUpdate;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +18,9 @@ import java.util.Map;
 @Tag(name = "posts", description = "피스레터 API")
 @RestController
 @RequestMapping("api/v1/post")
+@AllArgsConstructor
 public class PostController {
+    private final PostService postService;
 
     @GetPost
     @GetMapping("{postId}")
@@ -32,7 +36,8 @@ public class PostController {
     public ResponseEntity<CommonResponse<PostResponse>> create(
             @RequestBody PostRequest postRequest
     ) {
-        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.CREATED, "피스레터 생성이 완료되었습니다.", PostResponse.API_TEST());
+        PostResponse postResponse = postService.create(postRequest);
+        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.CREATED, "피스레터 생성이 완료되었습니다.", postResponse);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/findby/post/service/PostServiceImpl.java
+++ b/src/main/java/com/findby/post/service/PostServiceImpl.java
@@ -1,14 +1,45 @@
 package com.findby.post.service;
 
+import com.findby.image.Image;
+import com.findby.orphan.Orphan;
+import com.findby.orphan.service.dtos.OrphanResponse;
+import com.findby.post.Post;
+import com.findby.post.PostRepository;
 import com.findby.post.service.dtos.PostRequest;
 import com.findby.post.service.dtos.PostResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Service
+@AllArgsConstructor
 public class PostServiceImpl implements PostService {
+    private final PostRepository postRepository;
+
     @Override
     public PostResponse create(PostRequest request) {
-        return null;
+        Orphan orphan = Orphan.builder()
+                .name(request.getName())
+                .age(request.getAge())
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .gender(request.getGender())
+                .look(request.getLook())
+                .countryCode(request.getCountryCode())
+                .countryName(request.getCountryName()).build();
+
+        Post post = Post.of(
+                request.getPassword(), request.getTitle(), request.getContent(), request.getEmail(), orphan, request.getImageUrls()
+        );
+        postRepository.save(post);
+        OrphanResponse orphanResponse = OrphanResponse.of(
+                orphan.getOrphanId(), orphan.getName(), orphan.getAge(), orphan.getLatitude(), orphan.getLongitude(), orphan.getGender(), orphan.getLook(), orphan.getCountryCode(), orphan.getCountryName()
+        );
+        return PostResponse.of(
+                post.getPostId(), post.getTitle(), post.getContent(), post.getEmail(), post.getImages().stream().map(Image::getUrl).collect(Collectors.toList()), post.getIsDone(), post.getCreateAt(), post.getUpdateAt(), orphanResponse
+        );
     }
 
     @Override

--- a/src/main/java/com/findby/post/service/dtos/PostResponse.java
+++ b/src/main/java/com/findby/post/service/dtos/PostResponse.java
@@ -1,5 +1,6 @@
 package com.findby.post.service.dtos;
 
+import com.findby.orphan.service.dtos.OrphanResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,25 +14,15 @@ public class PostResponse {
     private final String title;
     private final String content;
     private final String email;
-    private final String name;
-    private final Integer age;
-    private final Double latitude;
-    private final Double longitude;
-    private final String gender;
-    private final String look;
-    private final String countryCode;
-    private final String countryName;
+    private final OrphanResponse orphan;
     private final List<String> imageUrls;
     private final Boolean isDone;
     private final LocalDateTime createAt;
     private final LocalDateTime updateAt;
 
     public static PostResponse API_TEST() {
-        return new PostResponse(
+        OrphanResponse orphanResponse = OrphanResponse.of(
                 1L,
-                "우리 아이를 찾아주세요.",
-                "블라블라",
-                "findby@findby.com",
                 "alice",
                 9,
                 124.1234,
@@ -39,11 +30,33 @@ public class PostResponse {
                 "female",
                 "눈 밑에 점이 있고, 왼쪽 볼에 흉터가 있습니다",
                 "UA",
-                "UKRAINE",
+                "UKRAINE");
+        return new PostResponse(
+                1L,
+                "우리 아이를 찾아주세요.",
+                "블라블라",
+                "findby@findby.com",
+                orphanResponse,
                 List.of(),
                 false,
                 LocalDateTime.now(),
                 LocalDateTime.now()
+        );
+    }
+
+    public static PostResponse of(
+            Long postId,
+            String title,
+            String content,
+            String email,
+            List<String> images,
+            boolean isDone,
+            LocalDateTime createAt,
+            LocalDateTime updateAt,
+            OrphanResponse orphan
+    ) {
+        return new PostResponse(
+                postId, title, content, email, orphan, images, isDone, createAt, updateAt
         );
     }
 }


### PR DESCRIPTION
PeaceLetter (Post) 생성 기능 구현

### PeaceLetter Response DTO 구조 변경
- 기존에는 PostResponse에 Post, Orphan, Image의 모든 필드를 한번에 저장
- 변경 후, Post와 Orphan 각자 ResponseDTO를 가지는 구조로 변경

### PeaceLetter 생성 서비스 로직 구현
- PostRepository 하나만을 이용하여 Orphan 및 Images 모두 저장 가능하도록 관계 연결

### PeaceLetter Controller create api PostService create 메서드 연결
- 기존 구현했던 create API가 더미 데이터를 응답하는 것이 아닌 실제 비즈니스 로직을 호출 및 결과를 응답하도록 수정