### PR TITLE
Post(PeaceLetter) 수정 기능 구현

### DIFF
--- a/src/main/java/com/findby/common/exception/BadRequestException.java
+++ b/src/main/java/com/findby/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.findby.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+    private final HttpStatus status;
+
+    public BadRequestException(String message) {
+        super(message);
+        this.status = HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/findby/common/exception/ForbiddenException.java
+++ b/src/main/java/com/findby/common/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.findby.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+    private final HttpStatus status;
+
+    public ForbiddenException(String message) {
+        super(message);
+        this.status = HttpStatus.FORBIDDEN;
+    }
+}

--- a/src/main/java/com/findby/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/findby/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.findby.common.exception;
+
+import com.findby.common.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<CommonResponse<Object>> handle(BadRequestException e) {
+        CommonResponse<Object> response = new CommonResponse<>(e.getStatus(), e.getMessage(), null);
+        return ResponseEntity.status(e.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<CommonResponse<Object>> handle(ForbiddenException e) {
+        CommonResponse<Object> response = new CommonResponse<>(e.getStatus(), e.getMessage(), null);
+        return ResponseEntity.status(e.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/findby/orphan/Orphan.java
+++ b/src/main/java/com/findby/orphan/Orphan.java
@@ -34,4 +34,16 @@ public class Orphan {
     public Orphan() {
 
     }
+
+    public Orphan update(String name, Integer age, Double latitude, Double longitude, String gender, String look, String countryCode, String countryName) {
+        this.name = name;
+        this.age = age;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.gender = gender;
+        this.look = look;
+        this.countryCode = countryCode;
+        this.countryName = countryName;
+        return this;
+    }
 }

--- a/src/main/java/com/findby/orphan/service/OrphanService.java
+++ b/src/main/java/com/findby/orphan/service/OrphanService.java
@@ -1,0 +1,8 @@
+package com.findby.orphan.service;
+
+import com.findby.orphan.Orphan;
+import com.findby.orphan.service.dtos.OrphanUpdate;
+
+public interface OrphanService {
+    Orphan update(Orphan orphan, OrphanUpdate update);
+}

--- a/src/main/java/com/findby/orphan/service/OrphanServiceImpl.java
+++ b/src/main/java/com/findby/orphan/service/OrphanServiceImpl.java
@@ -1,0 +1,25 @@
+package com.findby.orphan.service;
+
+import com.findby.orphan.Orphan;
+import com.findby.orphan.service.dtos.OrphanUpdate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrphanServiceImpl implements OrphanService {
+
+    @Override
+    @Transactional
+    public Orphan update(Orphan orphan, OrphanUpdate update) {
+        return orphan.update(
+                update.getName(),
+                update.getAge(),
+                update.getLatitude(),
+                update.getLongitude(),
+                update.getGender(),
+                update.getLook(),
+                update.getCountryCode(),
+                update.getCountryName()
+        );
+    }
+}

--- a/src/main/java/com/findby/orphan/service/dtos/OrphanUpdate.java
+++ b/src/main/java/com/findby/orphan/service/dtos/OrphanUpdate.java
@@ -1,0 +1,29 @@
+package com.findby.orphan.service.dtos;
+
+import com.findby.post.service.dtos.PostRequest;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrphanUpdate {
+    private String name;
+    private Integer age;
+    private Double latitude;
+    private Double longitude;
+    private String gender;
+    private String look;
+    private String countryCode;
+    private String countryName;
+
+    public OrphanUpdate(PostRequest request) {
+        this.name = request.getName();
+        this.age = request.getAge();
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.gender = request.getGender();
+        this.look = request.getLook();
+        this.countryCode = request.getCountryCode();
+        this.countryName = request.getCountryName();
+    }
+}

--- a/src/main/java/com/findby/post/Post.java
+++ b/src/main/java/com/findby/post/Post.java
@@ -28,7 +28,7 @@ public class Post {
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "orphan_id")
-    public Orphan orphan;
+    private Orphan orphan;
 
     @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<Image> images = new ArrayList<>();
@@ -64,5 +64,22 @@ public class Post {
         return new Post(
                 password, title, content, orphan, images, LocalDateTime.now(), LocalDateTime.now(), false, email
         );
+    }
+
+    public void update(
+            String password,
+            String title,
+            String content,
+            String email,
+            Orphan orphan,
+            List<String> images
+    ) {
+        this.password = password;
+        this.title = title;
+        this.content = content;
+        this.email = email;
+        this.orphan = orphan;
+        this.images = images.stream().map((url) -> Image.of(url, this)).collect(Collectors.toList());
+        this.updateAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/findby/post/controller/PostController.java
+++ b/src/main/java/com/findby/post/controller/PostController.java
@@ -73,6 +73,7 @@ public class PostController {
             @PathVariable("postId") Long postId,
             @RequestParam("password") String password
     ) {
+        postService.delete(postId, password);
         CommonResponse<Object> response = new CommonResponse<>(HttpStatus.OK, "피스레터 삭제가 완료되었습니다.", null);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/findby/post/controller/PostController.java
+++ b/src/main/java/com/findby/post/controller/PostController.java
@@ -27,7 +27,8 @@ public class PostController {
     public ResponseEntity<CommonResponse<PostResponse>> get(
             @PathVariable("postId") Long postId
     ) {
-        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.OK, "피스레터 조회를 성공하였습니다.", PostResponse.API_TEST());
+        PostResponse postResponse = postService.getPost(postId);
+        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.OK, "피스레터 조회를 성공하였습니다.", postResponse);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/findby/post/controller/PostController.java
+++ b/src/main/java/com/findby/post/controller/PostController.java
@@ -62,7 +62,8 @@ public class PostController {
             @PathVariable("postId") Long postId,
             @RequestBody PostUpdate postUpdate
     ) {
-        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.OK, "피스레터 수정이 완료되었습니다.", PostResponse.API_TEST());
+        PostResponse postResponse = postService.update(postId, postUpdate);
+        CommonResponse<PostResponse> response = new CommonResponse<>(HttpStatus.OK, "피스레터 수정이 완료되었습니다.", postResponse);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/findby/post/service/PostService.java
+++ b/src/main/java/com/findby/post/service/PostService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface PostService {
     PostResponse create(PostRequest request);
-    PostRequest getPost(Long postId);
+    PostResponse getPost(Long postId);
     void delete(Long postId, String password);
     void end(Long postId, String password);
     List<PostResponse> getPosts (String... TBU);

--- a/src/main/java/com/findby/post/service/PostService.java
+++ b/src/main/java/com/findby/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.findby.post.service;
 
 import com.findby.post.service.dtos.PostRequest;
 import com.findby.post.service.dtos.PostResponse;
+import com.findby.post.service.dtos.PostUpdate;
 
 import java.util.List;
 
@@ -11,4 +12,5 @@ public interface PostService {
     void delete(Long postId, String password);
     void end(Long postId, String password);
     List<PostResponse> getPosts (String... TBU);
+    PostResponse update(Long postId, PostUpdate postUpdate);
 }

--- a/src/main/java/com/findby/post/service/PostServiceImpl.java
+++ b/src/main/java/com/findby/post/service/PostServiceImpl.java
@@ -51,8 +51,14 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public void delete(Long postId, String password) {
+        Post post = postRepository
+                .findById(postId)
+                .orElseThrow(() -> new BadRequestException("해당 피스레터가 존재하지 않습니다."));
 
+        isWriter(post, password);
+        postRepository.delete(post);
     }
 
     @Override

--- a/src/main/java/com/findby/post/service/PostServiceImpl.java
+++ b/src/main/java/com/findby/post/service/PostServiceImpl.java
@@ -1,5 +1,7 @@
 package com.findby.post.service;
 
+import com.findby.common.exception.BadRequestException;
+import com.findby.common.exception.ForbiddenException;
 import com.findby.image.Image;
 import com.findby.orphan.Orphan;
 import com.findby.orphan.service.OrphanService;
@@ -68,7 +70,7 @@ public class PostServiceImpl implements PostService {
     public PostResponse update(Long postId, PostUpdate postUpdate) {
         Post post = postRepository
                 .findById(postId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 피스레터입니다."));
+                .orElseThrow(() -> new BadRequestException("해당 피스레터가 존재하지 않습니다."));
 
         isWriter(post, postUpdate.getPassword());
         PostRequest request = postUpdate.getPostRequest();
@@ -89,7 +91,7 @@ public class PostServiceImpl implements PostService {
     private void isWriter(Post post, String password) {
         boolean equals = post.getPassword().equals(password);
         if (!equals) {
-            throw new RuntimeException("수정 권한이 존재하지 않습니다.");
+            throw new ForbiddenException("해당 피스레터를 수정할 수 있는 권한이 존재하지 않습니다.");
         }
     }
 

--- a/src/main/java/com/findby/post/service/PostServiceImpl.java
+++ b/src/main/java/com/findby/post/service/PostServiceImpl.java
@@ -2,13 +2,17 @@ package com.findby.post.service;
 
 import com.findby.image.Image;
 import com.findby.orphan.Orphan;
+import com.findby.orphan.service.OrphanService;
 import com.findby.orphan.service.dtos.OrphanResponse;
+import com.findby.orphan.service.dtos.OrphanUpdate;
 import com.findby.post.Post;
 import com.findby.post.PostRepository;
 import com.findby.post.service.dtos.PostRequest;
 import com.findby.post.service.dtos.PostResponse;
+import com.findby.post.service.dtos.PostUpdate;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,8 +21,10 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
+    private final OrphanService orphanService;
 
     @Override
+    @Transactional
     public PostResponse create(PostRequest request) {
         Orphan orphan = Orphan.builder()
                 .name(request.getName())
@@ -34,12 +40,7 @@ public class PostServiceImpl implements PostService {
                 request.getPassword(), request.getTitle(), request.getContent(), request.getEmail(), orphan, request.getImageUrls()
         );
         postRepository.save(post);
-        OrphanResponse orphanResponse = OrphanResponse.of(
-                orphan.getOrphanId(), orphan.getName(), orphan.getAge(), orphan.getLatitude(), orphan.getLongitude(), orphan.getGender(), orphan.getLook(), orphan.getCountryCode(), orphan.getCountryName()
-        );
-        return PostResponse.of(
-                post.getPostId(), post.getTitle(), post.getContent(), post.getEmail(), post.getImages().stream().map(Image::getUrl).collect(Collectors.toList()), post.getIsDone(), post.getCreateAt(), post.getUpdateAt(), orphanResponse
-        );
+        return getPostResponse(post, orphan);
     }
 
     @Override
@@ -60,5 +61,44 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostResponse> getPosts(String... TBU) {
         return null;
+    }
+
+    @Override
+    @Transactional
+    public PostResponse update(Long postId, PostUpdate postUpdate) {
+        Post post = postRepository
+                .findById(postId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 피스레터입니다."));
+
+        isWriter(post, postUpdate.getPassword());
+        PostRequest request = postUpdate.getPostRequest();
+        OrphanUpdate orphanUpdate = new OrphanUpdate(request);
+        Orphan orphan = orphanService.update(post.getOrphan(), orphanUpdate);
+        post.update(
+                request.getPassword(),
+                request.getTitle(),
+                request.getContent(),
+                request.getEmail(),
+                orphan,
+                request.getImageUrls()
+        );
+
+        return getPostResponse(post, orphan);
+    }
+
+    private void isWriter(Post post, String password) {
+        boolean equals = post.getPassword().equals(password);
+        if (!equals) {
+            throw new RuntimeException("수정 권한이 존재하지 않습니다.");
+        }
+    }
+
+    private PostResponse getPostResponse(Post post, Orphan orphan) {
+        OrphanResponse orphanResponse = OrphanResponse.of(
+                orphan.getOrphanId(), orphan.getName(), orphan.getAge(), orphan.getLatitude(), orphan.getLongitude(), orphan.getGender(), orphan.getLook(), orphan.getCountryCode(), orphan.getCountryName()
+        );
+        return PostResponse.of(
+                post.getPostId(), post.getTitle(), post.getContent(), post.getEmail(), post.getImages().stream().map(Image::getUrl).collect(Collectors.toList()), post.getIsDone(), post.getCreateAt(), post.getUpdateAt(), orphanResponse
+        );
     }
 }

--- a/src/main/java/com/findby/post/service/PostServiceImpl.java
+++ b/src/main/java/com/findby/post/service/PostServiceImpl.java
@@ -46,8 +46,12 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostRequest getPost(Long postId) {
-        return null;
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository
+                .findById(postId)
+                .orElseThrow(() -> new BadRequestException("해당 피스레터가 존재하지 않습니다."));
+
+        return getPostResponse(post, post.getOrphan());
     }
 
     @Override


### PR DESCRIPTION
## 작업 내용

### 예외 및 글로벌 예외 핸들러 구현
- `GlobalExceptionHandler`
- `BadRequestException`
- `ForbiddenException`

### `OrphanService` 작성
- `Post` 업데이트 시, Orphan 업데이트 진행을 위해 구현

### `PostService` `update` 추가 구현
- `Post`의 전체 데이터 수정하는 방식으로 업데이트 기능 구현
- 비밀번호가 틀린 경우 403 예외 처리
- 잘못된 `PostId`로 수정 요청 시, 400 예외 처리

### `Post` 삭제 기능 구현
- `PostService`의 `delete` 메서드 상세 구현
- 비밀번호가 틀린 경우 403 예외 처리
- 잘못된 `PostId`로 수정 요청 시, 400 예외 처리

### `Post` 단일 조회 기능 구현
- `PostService`의 `getPost` 메서드 상세 구현
- 존재하지 않는 `post id`로 요청 시, 400 예외 처리